### PR TITLE
お宝を発見したら、ダイアログが表示されるように変更。

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -3,6 +3,20 @@
   <component name="AppInsightsSettings">
     <option name="tabSettings">
       <map>
+        <entry key="Android Vitals">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="com.takuchan.dialife" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="SEVEN_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
         <entry key="Firebase Crashlytics">
           <value>
             <InsightsFilterSettings>

--- a/app/src/main/java/com/takuchan/uwbviaserial/MainActivity.kt
+++ b/app/src/main/java/com/takuchan/uwbviaserial/MainActivity.kt
@@ -78,15 +78,23 @@ class MainActivity : ComponentActivity() {
                     viewModel.showTimerFinishedDialog()
                 }
 
-                if (uiState.proximityVibrationAnchorId == 4){
-                    vibrator.vibrate(VibrationEffect.createOneShot(1000, VibrationEffect.DEFAULT_AMPLITUDE))
-                }else if(uiState.proximityVibrationAnchorId == 3){
-                    vibrator.vibrate(VibrationEffect.createOneShot(300, VibrationEffect.DEFAULT_AMPLITUDE))
-                }else if(uiState.proximityVibrationAnchorId == 2){
-                    vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
-                }else if(uiState.proximityVibrationAnchorId == 1){
-                    vibrator.vibrate(VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE))
+                if(uiState.gameState == GameState.PLAYING){
+                    when (uiState.proximityVibrationAnchorId) {
+                        4 -> {
+                            vibrator.vibrate(VibrationEffect.createOneShot(1000, VibrationEffect.DEFAULT_AMPLITUDE))
+                        }
+                        3 -> {
+                            vibrator.vibrate(VibrationEffect.createOneShot(300, VibrationEffect.DEFAULT_AMPLITUDE))
+                        }
+                        2 -> {
+                            vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
+                        }
+                        1 -> {
+                            vibrator.vibrate(VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE))
+                        }
+                    }
                 }
+
 
 
                 val lifecycleOwner = LocalLifecycleOwner.current
@@ -117,15 +125,33 @@ class MainActivity : ComponentActivity() {
                         startActivity(intent)
                     },
                     onSetCountDownTime = { viewModel.setCountDown(it) },
-                    onAnchorDistancesSave = { d01, d02, d12 -> viewModel.updateAnchorDistances(d01, d02, d12) },
+                    onAnchorDistancesSave = { d01, d02, d12 ->
+                        viewModel.updateAnchorDistances(
+                            d01,
+                            d02,
+                            d12
+                        )
+                    },
                     onTimerFinishedDialogDismiss = { viewModel.hideTimerFinishedDialog() },
-                    onRoomSettingsSave = { width, height -> viewModel.updateRoomSize(width, height) },
-                    onAnchorPositionUpdate = { anchorIndex, x, y -> viewModel.updateAnchorPosition(anchorIndex, x, y) },
+                    onRoomSettingsSave = { width, height ->
+                        viewModel.updateRoomSize(
+                            width,
+                            height
+                        )
+                    },
+                    onAnchorPositionUpdate = { anchorIndex, x, y ->
+                        viewModel.updateAnchorPosition(
+                            anchorIndex,
+                            x,
+                            y
+                        )
+                    },
                     onErrorDialogDismiss = { viewModel.hideErrorDialog() }, // 追加
                     showSettingsDialog = showSettingsDialog,
                     showRoomSettingsDialog = showRoomSettingsDialog,
                     onSettingsDialogDismiss = { showSettingsDialog = false },
-                    onRoomSettingsDialogDismiss = { showRoomSettingsDialog = false }
+                    onRoomSettingsDialogDismiss = { showRoomSettingsDialog = false },
+                    onFinishedGame = {viewModel.hideFinishedDialog()}
                 )
             }
         }

--- a/app/src/main/java/com/takuchan/uwbviaserial/MainActivityViewModel.kt
+++ b/app/src/main/java/com/takuchan/uwbviaserial/MainActivityViewModel.kt
@@ -532,9 +532,12 @@ class MainActivityViewModel @Inject constructor(
      * ゲーム終了ダイアログの非表示
      */
     fun hideFinishedDialog(){
+        countdownJob?.cancel()
         _uiState.value = _uiState.value.copy(
             gameState = GameState.SETUP,
-            proximityVibrationAnchorId = null
+            proximityVibrationAnchorId = null,
+            isTimerRunning = false,
+            timerFinished = true,
         )
     }
 

--- a/app/src/main/java/com/takuchan/uwbviaserial/ui/components/GameRoomView.kt
+++ b/app/src/main/java/com/takuchan/uwbviaserial/ui/components/GameRoomView.kt
@@ -3,13 +3,17 @@ package com.takuchan.uwbviaserial.ui.components
 import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -24,6 +28,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.takuchan.uwbconnect.ui.theme.UWBviaSerialTheme
 import com.takuchan.uwbviaserial.MainActivityUiState
 import com.takuchan.uwbviaserial.UwbCoordinate
 import com.takuchan.uwbviaserial.ui.theme.ComponentsColor
@@ -74,6 +79,24 @@ fun GameRoomView(
                     .align(Alignment.TopEnd)
                     .padding(16.dp)
             )
+
+            if(uiState.proximityVibrationAnchorId == 2){
+                Text(
+                    text = "😯",
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 16.dp)
+                )
+            }else if(uiState.proximityVibrationAnchorId == 3){
+                Text(
+                    text = "おぉっ",
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 16.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.displayLarge
+                )
+            }
         }
     }
 }
@@ -127,10 +150,6 @@ private fun DrawScope.drawGameRoom(uiState: MainActivityUiState) {
     // タグを描画
     drawTag(uiState.tag, ::coordToPixel)
 
-    // 隠されたUWBを描画（点滅効果付き）
-    if (uiState.isTimerRunning) {
-        drawHiddenTreasure(uiState.hiddenTag, ::coordToPixel)
-    }
 }
 
 
@@ -217,35 +236,17 @@ fun DrawScope.drawTag(
     )
 }
 
-fun DrawScope.drawHiddenTreasure(
-    hiddenTag: UwbCoordinate,
-    coordToPixel: (Double, Double) -> Offset
-) {
-    val center = coordToPixel(hiddenTag.x, hiddenTag.y)
-    val radius = 20.dp.toPx()
-
-    // 宝箱のような形で描画
-    drawCircle(
-        color = ComponentsColor.HiddenTag,
-        radius = radius,
-        center = center
-    )
-
-    // 宝箱のハイライト
-    drawCircle(
-        color = Color.White.copy(alpha = 0.3f),
-        radius = radius * 0.7f,
-        center = center
-    )
-}
 
 @Preview(showBackground = true)
 @Composable
 private fun PreviewGameRoomView(){
-    GameRoomView(
-        uiState = MainActivityUiState(),
-        onAnchorPositionUpdate = {it,it2,it3->
+    UWBviaSerialTheme {
+        GameRoomView(
+            uiState = MainActivityUiState(),
+            onAnchorPositionUpdate = {it,it2,it3->
 
-        }
-    )
+            }
+        )
+    }
+
 }

--- a/app/src/main/java/com/takuchan/uwbviaserial/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/takuchan/uwbviaserial/ui/screens/MainScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.takuchan.uwbviaserial.GameState
 import com.takuchan.uwbviaserial.MainActivityUiState
 import com.takuchan.uwbviaserial.ui.components.AnchorSettingsDialog
 import com.takuchan.uwbviaserial.ui.components.ErrorDialog
@@ -38,6 +39,7 @@ fun MainScreen(
     onSetCountDownTime: (Int) -> Unit,
     onAnchorDistancesSave: (Double, Double, Double) -> Unit,
     onTimerFinishedDialogDismiss: () -> Unit,
+    onFinishedGame: () -> Unit,
     onRoomSettingsSave: (Double, Double) -> Unit,
     onAnchorPositionUpdate: (Int, Double, Double) -> Unit,
     onErrorDialogDismiss: () -> Unit, // 追加
@@ -134,9 +136,9 @@ fun MainScreen(
             )
         }
 
-        if(uiState.proximityVibrationAnchorId == 4){
+        if((uiState.gameState == GameState.PLAYING || uiState.gameState == GameState.FINISHED) && uiState.proximityVibrationAnchorId == 4){
             TreasureFoundDialog(
-                onErrorDialogDismiss
+                onDismiss = onFinishedGame
             )
         }
 
@@ -169,7 +171,8 @@ private fun PreviewMainScreen(){
             showRoomSettingsDialog = false,
             onSettingsDialogDismiss = {},
             onRoomSettingsDialogDismiss = {},
-            onStatusButtonClick = {}
+            onStatusButtonClick = {},
+            onFinishedGame = {  }
         )
     }
 }

--- a/app/src/main/java/com/takuchan/uwbviaserial/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/takuchan/uwbviaserial/ui/screens/MainScreen.kt
@@ -136,11 +136,12 @@ fun MainScreen(
             )
         }
 
-        if((uiState.gameState == GameState.PLAYING || uiState.gameState == GameState.FINISHED) && uiState.proximityVibrationAnchorId == 4){
+        if (uiState.showTreasureFoundDialog) {
             TreasureFoundDialog(
                 onDismiss = onFinishedGame
             )
         }
+
 
         // エラーダイアログを追加
         if (uiState.showErrorDialog) {


### PR DESCRIPTION
# Overview
- お宝を発見したときの`uistate`周りの改修工事
- お宝に接近したときにユーザーに視覚的にお宝が近いことを明記。

# 変更箇所
MainActivityViewModel.ktに`hideFinishedDialog`関数を追加し、宝が見つかったときのダイアログでボタンを押すと必要なパラメータはリセットされるように変更
```
        _uiState.value = _uiState.value.copy(
            gameState = GameState.SETUP,
            proximityVibrationAnchorId = null,
            isTimerRunning = false,
            timerFinished = true,
        )
```

GameRoomView()にて、宝に設計したときに画面上に絵文字やテキストなど近づいていることを明記するようにした。
